### PR TITLE
Build window wheels on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+environment:
+  password:
+    secure: uOcv5TOm/CgwOmiLQhNX+g==
+
+  matrix:
+    - python : 26
+    - python : 26-x64  
+    - python : 27
+    - python : 27-x64
+    - python : 33
+    - python : 33-x64
+    - python : 34
+    - python : 34-x64
+    - python : 35	
+    - python : 35-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
+  - git submodule update --init --recursive
+  - pip install cython argparse pytest
+  - ./update_cpp.sh
+  - pip install -e . 
+
+build: false
+
+test_script:
+  - py.test tests --doctest-modules
+
+on_success:
+  - echo Build succesful!
+
+deploy_script:
+  - echo [distutils]                                  > %USERPROFILE%\\.pypirc
+  - echo index-servers =                             >> %USERPROFILE%\\.pypirc
+  - echo     pypi                                    >> %USERPROFILE%\\.pypirc
+  - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
+  - echo repository=https://pypi.python.org/pypi     >> %USERPROFILE%\\.pypirc
+  - echo username=zope.wheelbuilder                  >> %USERPROFILE%\\.pypirc
+  - echo password=%password%                         >> %USERPROFILE%\\.pypirc
+  - set HOME=%USERPROFILE%
+  - pip install wheel twine
+  - ps: if($env:APPVEYOR_REPO_TAG -eq $TRUE) { python -W ignore setup.py bdist_wheel bdist_egg && twine upload dist/* }
+
+deploy : on


### PR DESCRIPTION
This scripts will

* test python-crfsuite on windows
* on tagged commites, build and deploy wheels to pypi

You'll need to enable appveyor for this repo: https://www.appveyor.com/docs

