### PR TITLE
Fix the build with gcc prior to 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ if sys.platform == 'win32':
 ext_modules = [Extension('pycrfsuite._pycrfsuite',
     include_dirs=includes,
     language='c++',
+    extra_compile_args=['-std=c99'],
     sources=sources
 )]
 


### PR DESCRIPTION
**Got import error with gcc below 5.0**
ImportError: python-crfsuite-0.8.4/pycrfsuite/_pycrfsuite.cpython-35m-x86_64-linux-gnu.so: undefined symbol: isfinite

**Build warning**
crfsuite/lib/crf/src/train_l2sgd.c:197: warning: implicit declaration of function 'isfinite'

"isfinite" can be used after c99 but, with gcc below 5.0, c89 is used by default.
Added compiler option to -std=c99 to use c99 in setup.py.